### PR TITLE
add function to compute umaa-romaa lithology

### DIFF
--- a/petrophysics/lithology/__init__.py
+++ b/petrophysics/lithology/__init__.py
@@ -1,10 +1,11 @@
-from .lithology import m,n,romaa,dtmaa,umaa
+from .lithology import m,n,romaa,dtmaa,umaa,ur_lith
 
 __all__ = ['m',
            'n',
            'romaa',
            'dtmaa',
-           'umaa'
+           'umaa',
+           'ur_lith',
            ]
 
 


### PR DESCRIPTION
Added a function to the `lithology.py ` file that uses umaa and romaa to estimate lithology based on the Umaa-Rhomaa ternary diagram of Quartz, Calcite, and Dolomite ([for example](http://wiki.aapg.org/images/e/eb/Difficult-lithologies_fig3.png)).

In the future it could be useful to add functionality to allow for changes to the values of endpoints, for instance to switch from dolomite to illite. But this is a start.